### PR TITLE
ENH: DataFrame.explode() allow for multiple columns

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6310,7 +6310,7 @@ class DataFrame(NDFrame):
             for c in columns:
                 tmp[c] = self[c].explode()
         else:
-            raise ValueError("lengths of lists in the same row not equal")
+            raise ValueError("Exploded lists from `columns` do not have equivalent length within the same record")
         
         # join in exploded columns
         results = self.drop(columns, axis=1).join(tmp)


### PR DESCRIPTION
Now if you pass a list of column names to .explode(), so long as all the lengths of lists are consistent across all the columns for each records, all the columns will be exploded.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
