### PR TITLE
ENH: DataFrame.explode() multiple columns

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6298,7 +6298,7 @@ class DataFrame(NDFrame):
         lengths_equal = []
         
         for row in self[columns].iterrows():
-            # converts non-lists into 1 element lists
+            # converts non-lists into 1 element lists so len() is valid
             r=row[1].apply(lambda x: x if type(x) in (list,tuple) else [x]) 
             
             # make sure all lists in the same record are the same length

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6207,14 +6207,15 @@ class DataFrame(NDFrame):
 
     def explode(self, columns: Union[str, List[str]]) -> "DataFrame":
         """
-        Transform each element of a list-like to a row, replicating the index values.
+        Transform each element of a list-like to a row, replicating index values.
 
         .. versionadded:: 0.25.0
 
         Parameters
         ----------
-        column : str or tuple
-
+        columns : str or list
+            the column(s) to be exploded
+            
         Returns
         -------
         DataFrame


### PR DESCRIPTION
Now explode() can also take in a list of columns and explode them all, given that for every record in the dataframe the elements of the exploding columns all have the same length

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `black pandas`
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
